### PR TITLE
Fix reading data from BufferedReader

### DIFF
--- a/src/encode/vorbis.rs
+++ b/src/encode/vorbis.rs
@@ -41,7 +41,7 @@ pub(super) fn encode<R: Read, W: Write>(
     let stream_size = info.size.get() as usize;
     let mut window = PreviousWindowRight::new();
 
-    while source.position() - start_pos < stream_size {
+    while source.position() - start_pos < (stream_size - 1){
         let packet_size = source
             .le_u16()
             .map_err(VorbisError::from_read(VorbisErrorKind::ReadPacket))?;


### PR DESCRIPTION
read() will do partial reads from BufferedReader, if requested size exeeds size remainig buffered data. Next read() from BufferedReader will cause it to read next chunk from underlying Reader into a buffer. However, all Readers provide read_exact() which will do exactly what is needed. This should fix issue #1 